### PR TITLE
Update util.py LinearRegression call

### DIFF
--- a/gemmr/util.py
+++ b/gemmr/util.py
@@ -298,7 +298,7 @@ def pc_spectrum_decay_constant(X=None, pc_spectrum=None,
         y = pc_spectrum_nrm[:nc]
 
         lm = LinearRegression(
-            fit_intercept=True, normalize=False
+            fit_intercept=True
         ).fit(
             np.log(X).reshape(-1, 1),
             np.log(y)


### PR DESCRIPTION
No parameter for normalize exists in updated version of utilized package, so it was removed.